### PR TITLE
Give the tests a longer timeout

### DIFF
--- a/test/erlscrypt_test.erl
+++ b/test/erlscrypt_test.erl
@@ -56,7 +56,9 @@ startup_test() ->
     ?assertNot(undefined == whereis(erlscrypt)).
 
 scrypt_test_() ->
-    {inparallel, test_internal(port) ++ test_internal(nif)}.
+    {timeout,
+     20,
+     {inparallel, test_internal(port) ++ test_internal(nif)}}.
 
 test_internal(Type) ->
     [{list_to_binary(io_lib:format("[~p] ~p. '~s'/'~s'",


### PR DESCRIPTION
On my laptop, the final test fails more than half the time because it hits the default timeout (5 seconds). This gives the tests a generous 20 seconds to run. 

I wasn't sure how you like your whitespace.
